### PR TITLE
Allow ignoring images below a cutoff dimension

### DIFF
--- a/document_processing/FolderProcessor.py
+++ b/document_processing/FolderProcessor.py
@@ -1,21 +1,30 @@
 from pathlib import Path
 from typing import Any, Dict, List
+from tqdm import tqdm
 
 
 class FolderProcessor:
     """Handles processing of a folder containing multiple documents."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, limit_documents: int = None, pdf_only: bool = True):
         from .DocumentProcessor import DocumentProcessor
         from .ImageProcessor import ImageProcessor
         from .PageProcessor import PageProcessor
         from .TextProcessor import TextProcessor
         self.path: Path = path
+        if pdf_only:
+            files = list(self.path.glob("*.pdf"))
+        else:
+            files = list(self.path.iterdir())
+            
         self.documents: List[DocumentProcessor] = [
             DocumentProcessor(self, file_path)
-            for file_path in self.path.iterdir()
+            for file_path in tqdm(files, desc="Processing documents")
             if file_path.is_file()
         ]
+        if limit_documents:
+            self.documents = self.documents[:limit_documents]
+
         self.all_pages: List[PageProcessor] = []
         self.all_texts: List[TextProcessor] = []
         self.all_images: List[ImageProcessor] = []

--- a/document_processing/PageProcessor.py
+++ b/document_processing/PageProcessor.py
@@ -16,7 +16,7 @@ from .utils import (apply_mask, paste_on_white_background, pixmap_to_image,
 
 
 class PageProcessor(EmbeddableAbstract, DescribableAbstract):
-    def __init__(self, folder: 'FolderProcessor', document: 'DocumentProcessor', number: int, page: pymupdf.Page):
+    def __init__(self, folder: 'FolderProcessor', document: 'DocumentProcessor', number: int, page: pymupdf.Page, img_cutoff_dim: int = 160):
         from .ImageProcessor import ImageProcessor
         from .TextProcessor import TextProcessor
 
@@ -47,6 +47,8 @@ class PageProcessor(EmbeddableAbstract, DescribableAbstract):
         # Extract and initialize individual images on the page
         self.images: List[ImageProcessor] = [ImageProcessor(
             folder, document, self, index, content=image) for index, image in enumerate(document_images)]
+        
+        self.images: List[ImageProcessor] = [image for image in self.images if image.content.size[0] > img_cutoff_dim and image.content.size[1] > img_cutoff_dim]
 
         self.record: Dict[str, Any] = {
             "id": f"{self.document.path.stem}_page_{self.page.number}",
@@ -58,6 +60,7 @@ class PageProcessor(EmbeddableAbstract, DescribableAbstract):
                 "document_path": str(self.document.path.resolve()),
                 "page": self.page.number,
                 "page_path": str(self.image_path.resolve())
+                # TODO: Resolve make the path absolute with respect to the current working directory! Better to have it relative
             },
             # embedding is set in the function set_embedding
             "embedding": None


### PR DESCRIPTION
Small updates to speedup the generation ignoring template images (the smaller ones below a cutoff)